### PR TITLE
Fix #33316 now add support for highlight for Unity 5.4+ built-in matrix variables

### DIFF
--- a/grammars/shaderlab.json
+++ b/grammars/shaderlab.json
@@ -145,7 +145,7 @@
 				},
 				{
 					"name": "support.variable.transformations.shaderlab",
-					"match": "\\b(UNITY_MATRIX_MVP|UNITY_MATRIX_MV|UNITY_MATRIX_V|UNITY_MATRIX_P|UNITY_MATRIX_VP|UNITY_MATRIX_T_MV|UNITY_MATRIX_IT_MV|_Object2World|_World2Object)\\b"
+					"match": "\\b(UNITY_MATRIX_MVP|UNITY_MATRIX_MV|UNITY_MATRIX_M|UNITY_MATRIX_V|UNITY_MATRIX_P|UNITY_MATRIX_VP|UNITY_MATRIX_T_MV|UNITY_MATRIX_I_V|UNITY_MATRIX_IT_MV|_Object2World|_World2Object|unity_ObjectToWorld|unity_WorldToObject)\\b"					
 				},
 				{
 					"name": "support.variable.camera.shaderlab",


### PR DESCRIPTION
This fix is required by @aeschli to solve this issue
https://github.com/Microsoft/vscode/issues/33316

add support for UNITY_MATRIX_M|UNITY_MATRIX_I_V|unity_ObjectToWorld|unity_WorldToObject, which were introduced in Unity 5.4+

Please update this, thanks!